### PR TITLE
Add target for programming stm32f4-discovery eval boards

### DIFF
--- a/Makefile.f4
+++ b/Makefile.f4
@@ -48,3 +48,8 @@ upload: all flash-bootloader
 
 flash-bootloader:
 	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY)" -c "reset run" -c shutdown
+
+# Use to upload to a stm32f4-discovery devboard, requires the latest version of openocd (from git)
+# build openocd with "cd openocd; ./bootstrap; ./configure --enable-maintainer-mode --enable-stlink"
+upload-discovery: 
+	$(OPENOCD) --search ../px4_bootloader -f board/stm32f4discovery.cfg -c init -c "reset halt" -c "flash probe 0" -c "stm32f2x mass_erase 0" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset" -c shutdown


### PR DESCRIPTION
(I'm not sure if this is the ideal way to do this, but it worked for me.  Feedback is welcome.  I'll also add some details on the PX4 wiki)

The current openocd now has built-in support built in support for the
stm32f4-discovery board.  So this target does not need the stm32f4x.cfg
config file (and in fact, that file is not correct because the discovery
includes a built in st-link debug device).

To program the PX4 bootloader onto the discovery:
make
make -f Makefile.f4 TARGET=discovery upload-discovery
