### PR TITLE
Openocd now expects an offset for image writes

### DIFF
--- a/Makefile.f4
+++ b/Makefile.f4
@@ -47,7 +47,7 @@ $(BINARY):	$(ELF)
 upload: all flash-bootloader
 
 flash-bootloader:
-	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY)" -c "reset run" -c shutdown
+	$(OPENOCD) --search ../px4_bootloader -f $(JTAGCONFIG) -f stm32f4x.cfg -c init -c "reset halt" -c "flash write_image erase $(BINARY) 0x08000000" -c "reset run" -c shutdown
 
 # Use to upload to a stm32f4-discovery devboard, requires the latest version of openocd (from git)
 # build openocd with "cd openocd; ./bootstrap; ./configure --enable-maintainer-mode --enable-stlink"


### PR DESCRIPTION
An update to work with the current version of openocd
