### PR TITLE
allow uploader script to read OTP and SN from the v4 boards

### DIFF
--- a/px_uploader.py
+++ b/px_uploader.py
@@ -418,14 +418,17 @@ class uploader(object):
                 self.port.close()
                 
         def send_reboot(self):
-                # try reboot via NSH first
-                self.__send(uploader.NSH_INIT)
-                self.__send(uploader.NSH_REBOOT_BL)
-                self.__send(uploader.NSH_INIT)
-                self.__send(uploader.NSH_REBOOT)
-                # then try MAVLINK command
-                self.__send(uploader.MAVLINK_REBOOT_ID1)
-                self.__send(uploader.MAVLINK_REBOOT_ID0)
+                try:
+                    # try reboot via NSH first
+                    self.__send(uploader.NSH_INIT)
+                    self.__send(uploader.NSH_REBOOT_BL)
+                    self.__send(uploader.NSH_INIT)
+                    self.__send(uploader.NSH_REBOOT)
+                    # then try MAVLINK command
+                    self.__send(uploader.MAVLINK_REBOOT_ID1)
+                    self.__send(uploader.MAVLINK_REBOOT_ID0)
+                except:
+                    return
                 
                 
 


### PR DESCRIPTION
and display the info to the user/s, so they can see for themselves
what the serial number of their PX4/Pixhawk is.
