### PR TITLE
utf-8 does not handle 0xFF characters.

### DIFF
--- a/px_uploader.py
+++ b/px_uploader.py
@@ -381,7 +381,7 @@ class uploader(object):
                     for byte in range(0,32*6,4):
                         x = self.__getOTP(byte)
                         self.otp  = self.otp + x
-                        print(binascii.hexlify(x).decode('utf-8') + ' ', end='')
+                        print(binascii.hexlify(x).decode('Latin-1') + ' ', end='')
                     # see src/modules/systemlib/otp.h in px4 code:
                     self.otp_id = self.otp[0:4]
                     self.otp_idtype = self.otp[4:5]
@@ -389,17 +389,17 @@ class uploader(object):
                     self.otp_pid = self.otp[12:8:-1]
                     self.otp_coa = self.otp[32:160]
                     # show user:
-                    print("type: " + self.otp_id.decode('utf-8'))
-                    print("idtype: " + binascii.b2a_qp(self.otp_idtype).decode('utf-8'))
-                    print("vid: " + binascii.hexlify(self.otp_vid).decode('utf-8'))
-                    print("pid: "+ binascii.hexlify(self.otp_pid).decode('utf-8'))
-                    print("coa: "+ binascii.b2a_base64(self.otp_coa).decode('utf-8'))
+                    print("type: " + self.otp_id.decode('Latin-1'))
+                    print("idtype: " + binascii.b2a_qp(self.otp_idtype).decode('Latin-1'))
+                    print("vid: " + binascii.hexlify(self.otp_vid).decode('Latin-1'))
+                    print("pid: "+ binascii.hexlify(self.otp_pid).decode('Latin-1'))
+                    print("coa: "+ binascii.b2a_base64(self.otp_coa).decode('Latin-1'))
                     print("sn: ", end='')
                     for byte in range(0,12,4):
                         x = self.__getSN(byte)
                         x = x[::-1]  # reverse the bytes
                         self.sn  = self.sn + x
-                        print(binascii.hexlify(x).decode('utf-8'), end='') # show user
+                        print(binascii.hexlify(x).decode('Latin-1'), end='') # show user
                     print('')
                 print("erase...")
                 self.__erase()


### PR DESCRIPTION
- 0xff appear in boards with no OTP or COA programmed.
- using Latin-1 encoding handles this better.

before:
Loaded firmware for 14,0, waiting for the bootloader...
Found board 14,0 bootloader rev 4 on /dev/cu.usbmodem1
ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff Traceback (most recent call last):
  File "/Users/buzz/UAV/Bootloader/px_uploader.py", line 507, in <module>
    up.upload(fw)
  File "/Users/buzz/UAV/Bootloader/px_uploader.py", line 392, in upload
    print("type: " + self.otp_id.decode('utf-8'))
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xff in position 0: invalid start byte

after: 
Loaded firmware for 14,0, waiting for the bootloader...
Found board 14,0 bootloader rev 4 on /dev/cu.usbmodem1
ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff ffffffff type: ÿÿÿÿ
idtype: =FF
vid: ffffffff
pid: ffffffff
coa: //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////8=
sn: 0012345678901234567890
erase...
program...
verify...
done, rebooting.

I tested this on both 2.7 and 3.0 pythons on OSX. 
