### PR TITLE
Add Gumstix AeroCore device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ px4fmu_bl.bin
 Bootloader.sublime-workspace
 .gdbinit
 px4fmuv2_bl.bin
+px4aerocore_bl.bin

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ export COMMON_SRCS	 = bl.c
 #
 # Bootloaders to build
 #
-TARGETS			 = px4fmu_bl px4fmuv2_bl px4flow_bl stm32f4discovery_bl px4io_bl
+TARGETS			 = px4fmu_bl px4fmuv2_bl px4flow_bl stm32f4discovery_bl px4io_bl aerocore_bl
 
 # px4io_bl px4flow_bl
 
@@ -63,6 +63,9 @@ stm32f4discovery_bl: $(MAKEFILE_LIST)
 
 px4flow_bl: $(MAKEFILE_LIST)
 	make -f Makefile.f4 TARGET=flow INTERFACE=USB BOARD=FLOW USBDEVICESTRING="\\\"PX4 FLOW v1.3\\\"" USBPRODUCTID="0x0015"
+
+aerocore_bl: $(MAKEFILE_LIST)
+	make -f Makefile.f4 TARGET=aerocore INTERFACE=USB BOARD=AEROCORE USBDEVICESTRING="\\\"Gumstix BL AEROCORE\\\"" USBPRODUCTID="0x1001"
 
 # Default bootloader delay is *very* short, just long enough to catch
 # the board for recovery but not so long as to make restarting after a 

--- a/main_f4.c
+++ b/main_f4.c
@@ -128,6 +128,27 @@ static struct {
 //# define BOARD_BOOT_FAIL_DETECT		/* V2 boards should support boot failure detection */
 #endif
 
+#ifdef BOARD_AEROCORE
+# define BOARD_TYPE			98
+# define BOARD_FLASH_SECTORS		23
+# define BOARD_FLASH_SIZE		(2048 * 1024)
+
+# define OSC_FREQ			24
+
+# define BOARD_PIN_LED_ACTIVITY		GPIO10	// Yellow
+# define BOARD_PIN_LED_BOOTLOADER	GPIO9	// Blue
+# define BOARD_PORT_LEDS		GPIOE
+# define BOARD_CLOCK_LEDS		RCC_AHB1ENR_IOPEEN
+# define BOARD_LED_ON			gpio_clear
+# define BOARD_LED_OFF			gpio_set
+
+# define BOARD_FORCE_BL_PIN_OUT		GPIO0	// J11 header, pin 1
+# define BOARD_FORCE_BL_PIN_IN		GPIO1	// J11 header, pin 3
+# define BOARD_FORCE_BL_PORT		GPIOB
+# define BOARD_FORCE_BL_CLOCK_REGISTER	RCC_AHB1ENR
+# define BOARD_FORCE_BL_CLOCK_BIT	RCC_AHB1ENR_IOPBEN
+# define BOARD_FORCE_BL_PULL		GPIO_PUPD_PULLUP
+#endif
 
 #define APP_SIZE_MAX			(BOARD_FLASH_SIZE - BOOTLOADER_RESERVATION_SIZE)
 


### PR DESCRIPTION
Based on the work of Andrew Smith [1], add board configuration to
support the Gumstix AeroCore (previously Aerodroid) board [2]. This
is an autopilot board based on a STM32F427 similar to the FMUv2.

[1] https://github.com/smithandrewc/Bootloader
[2] https://store.gumstix.com/index.php/products/585/

Signed-off-by: Ash Charles ashcharles@gmail.com
