### PR TITLE
WIP: Expose the chip serial number in the bootloader

### DIFF
--- a/cdcacm.c
+++ b/cdcacm.c
@@ -61,7 +61,7 @@
  *  and is hard coded in the usb lib. The array below is indexed by requested index-1, therefore
  *  element[0] maps to requested index 1
  */
-static const char *usb_strings[] = {
+static char *usb_strings[] = {
 	USBMFGSTRING, /* Maps to Index 1 Index */
 	USBDEVICESTRING,
 	"0",
@@ -289,6 +289,12 @@ otg_fs_isr(void)
 }
 
 void
+usb_set_sn(char * sn)
+{
+  usb_strings[2] = sn;
+}
+
+void
 usb_cinit(void)
 {
 #if defined(STM32F4)
@@ -318,8 +324,8 @@ usb_cinit(void)
 	OTG_FS_GCCFG |= OTG_GCCFG_NOVBUSSENS;
 #endif
 
-	usbd_dev = usbd_init(&otgfs_usb_driver, &dev, &config, usb_strings, NUM_USB_STRINGS,
-			     usbd_control_buffer, sizeof(usbd_control_buffer));
+        usbd_dev = usbd_init(&otgfs_usb_driver, &dev, &config, (const char **)usb_strings, NUM_USB_STRINGS,
+                                        usbd_control_buffer, sizeof(usbd_control_buffer));
 
 #elif defined(STM32F1)
 	rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPAEN);

--- a/cdcacm.h
+++ b/cdcacm.h
@@ -39,7 +39,7 @@
 
 #pragma once
 
-
+extern void usb_set_sn(char * sn);
 extern void usb_cinit(void);
 extern void usb_cfini(void);
 extern int usb_cin(void);


### PR DESCRIPTION
This <del>is still WIP and</del> relates to issue #20, exposing the chip serial in the bootloader.

@LorenzMeier : I assume you wanted to set the USB device descriptor iSerialNumber to the microcontroller serial number. This is a start down that path. I haven't yet managed to figure out how to get the UDID into a string that I can use for the USB serial number. Any help would be appreciated.

Note: It seems the the string that is used as the serial number for the USB has to be all capitals. It doesn't seem to work properly if it has lower case letter - that or I am doing something stupid to not make it work.
