### PR TITLE
WIP: Feature use internal oscillator

### DIFF
--- a/hw_config.h
+++ b/hw_config.h
@@ -55,6 +55,25 @@
  * SERIAL_BREAK_DETECT_DISABLED                -  Optional prevent break selection on Serial port from entering or staying in BL
  *
  * USE_INTERNAL_OSCILLATOR                     - Optional - if defined, then the internal oscillator is used as clock source
+ * CUSTOM_CLOCK_CONFIG                         - Optional - if defined, then another clock clock configuration other than the standard
+ *                                               STM32F4 clock configuration with a sysclock speed of 168MHz can be used. If using a custom
+ *                                               clock configuration, then the following defines must be specified:
+ *                                                - CLOCK_CONFIG_SYSTICK_MHZ
+ *                                                - CLOCK_CONFIG_PLL_M
+ *                                                - CLOCK_CONFIG_SYSTICK_MHZ
+ *                                                - CLOCK_CONFIG_PLL_M
+ *                                                - CLOCK_CONFIG_PLL_N
+ *                                                - CLOCK_CONFIG_PLL_P
+ *                                                - CLOCK_CONFIG_PLL_Q
+ *                                                - CLOCK_CONFIG_PLL_R
+ *                                                - CLOCK_CONFIG_HPRE
+ *                                                - CLOCK_CONFIG_PPRE1
+ *                                                - CLOCK_CONFIG_PPRE2
+ *                                                - CLOCK_CONFIG_POWER_SAVE
+ *                                                - CLOCK_CONFIG_FLASH_CONFIG
+ *                                                - CLOCK_CONFIG_APB1_FREQ
+ *                                                - CLOCK_CONFIG_APB2_FREQ
+ *                                               These defines are copied to the appropriate fields in the clock_setup struct.
  *
  * * Other defines are somewhat self explanatory.
  */

--- a/hw_config.h
+++ b/hw_config.h
@@ -54,6 +54,8 @@
  * USBMFGSTRING            "PX4 AP"            - Optional USB MFG string (default is '3D Robotics' if not defined.)
  * SERIAL_BREAK_DETECT_DISABLED                -  Optional prevent break selection on Serial port from entering or staying in BL
  *
+ * USE_INTERNAL_OSCILLATOR                     - Optional - if defined, then the internal oscillator is used as clock source
+ *
  * * Other defines are somewhat self explanatory.
  */
 #if  defined(TARGET_HW_PX4_FMU_V1)

--- a/main_f1.c
+++ b/main_f1.c
@@ -304,7 +304,7 @@ main(void)
 	/* do board-specific initialisation */
 	board_init();
 
-#if defined(INTERFACE_USART) | defined (INTERFACE_USB)
+#if defined(INTERFACE_USART) || defined (INTERFACE_USB)
 	/* XXX sniff for a USART connection to decide whether to wait in the bootloader? */
 	timeout = BOOTLOADER_DELAY;
 #endif

--- a/main_f4.c
+++ b/main_f4.c
@@ -148,8 +148,11 @@ struct boardinfo board_info = {
 	.board_type	= BOARD_TYPE,
 	.board_rev	= 0,
 	.fw_size	= 0,
-
-	.systick_mhz	= 168,
+#ifndef CUSTOM_CLOCK_CONFIG
+	.systick_mhz  = 168,
+#else
+	.systick_mhz  = CLOCK_CONFIG_SYSTICK_MHZ,
+#endif
 };
 
 static void board_init(void);
@@ -160,13 +163,14 @@ static void board_init(void);
 
 /* standard clocking for all F4 boards */
 static const struct rcc_clock_scale clock_setup = {
+#ifndef CUSTOM_CLOCK_CONFIG
 	.pllm = OSC_FREQ,
 	.plln = 336,
 	.pllp = 2,
 	.pllq = 7,
-#if defined(STM32F446) || defined(STM32F469)
+# if defined(STM32F446) || defined(STM32F469)
 	.pllr = 2,
-#endif
+# endif
 	.hpre = RCC_CFGR_HPRE_DIV_NONE,
 	.ppre1 = RCC_CFGR_PPRE_DIV_4,
 	.ppre2 = RCC_CFGR_PPRE_DIV_2,
@@ -174,6 +178,22 @@ static const struct rcc_clock_scale clock_setup = {
 	.flash_config = FLASH_ACR_ICE | FLASH_ACR_DCE | FLASH_ACR_LATENCY_5WS,
 	.apb1_frequency = 42000000,
 	.apb2_frequency = 84000000,
+#else
+	.pllm = CLOCK_CONFIG_PLL_M,
+	.plln = CLOCK_CONFIG_PLL_N,
+	.pllp = CLOCK_CONFIG_PLL_P,
+	.pllq = CLOCK_CONFIG_PLL_Q,
+# if defined(CLOCK_CONFIG_PLL_R)
+	.pllr = CLOCK_CONFIG_PLL_R,
+# endif
+	.hpre = CLOCK_CONFIG_HPRE,
+	.ppre1 = CLOCK_CONFIG_PPRE1,
+	.ppre2 = CLOCK_CONFIG_PPRE2,
+	.power_save = CLOCK_CONFIG_POWER_SAVE,
+	.flash_config = CLOCK_CONFIG_FLASH_CONFIG,
+	.apb1_frequency = CLOCK_CONFIG_APB1_FREQ,
+	.apb2_frequency = CLOCK_CONFIG_APB2_FREQ,
+#endif
 };
 
 static uint32_t

--- a/main_f7.c
+++ b/main_f7.c
@@ -452,7 +452,7 @@ clock_deinit(void)
 	rcc_css_disable();
 
 	/* Reset the RCC_PLLCFGR register */
-	RCC_PLLCFGR = 0x24003010; // XXX Magic reset number from STM32F4xx reference manual
+	RCC_PLLCFGR = 0x24003010; // XXX Magic reset number from STM32F7xx reference manual
 
 	/* Reset the HSEBYP bit */
 	rcc_osc_bypass_disable(RCC_HSE);


### PR DESCRIPTION
This branch adds the ability to use the internal oscillator and also to define a different clock configuration than the standard config. I was using an STM32F411, which has a maximum SYSCLK of 100MHz, and hence cannot use the standard clock config. These additions make it reasonably easy to add another chip that has a different clock speed and config options, by adding defines that are copied into the clock_setup struct.

I haven't added these changes to the main_f1.c, main_f3.c and main_f7.c files yet.

Have a look and tell me whether you think this could be useful.