### PR TITLE
Fixes erroneous USB VBUS Sense

### DIFF
--- a/hw_config.h
+++ b/hw_config.h
@@ -897,6 +897,12 @@
 # error Undefined Target Hardware
 #endif
 
+#if !defined(BOARD_PIN_VBUS)
+# define BOARD_PIN_VBUS                 GPIO9
+# define BOARD_PORT_VBUS                GPIOA
+# define BOARD_CLOCK_VBUS               RCC_AHB1ENR_IOPAEN
+#endif
+
 #if !defined(USBMFGSTRING)
 # define USBMFGSTRING "3D Robotics"
 #endif

--- a/main_f4.c
+++ b/main_f4.c
@@ -81,12 +81,6 @@ static struct {
 #define REVID_MASK	0xFFFF0000
 #define DEVID_MASK	0xFFF
 
-#ifndef BOARD_PIN_VBUS
-# define BOARD_PIN_VBUS                 GPIO9
-# define BOARD_PORT_VBUS                GPIOA
-# define BOARD_CLOCK_VBUS               RCC_AHB1ENR_IOPAEN
-#endif
-
 /* magic numbers from reference manual */
 
 typedef enum mcu_rev_e {

--- a/main_f7.c
+++ b/main_f7.c
@@ -237,21 +237,22 @@ board_test_force_pin()
 }
 
 #if INTERFACE_USB
-#if !defined(BOARD_USB_VBUS_SENSE_DISABLED)
 static bool
 board_test_usb_vbus()
 {
-	bool ret = false;
+	bool ret = true;
 
-	/* initialise pin to sample VBUS 
+/* only perform the USB VBUS check if VBUS_SENSE is not diasbled - if it is disabled, always return true */
+#if !defined(BOARD_USB_VBUS_SENSE_DISABLED)
+	/* initialise pin to sample VBUS
 	 * This is usually PA9, but could be configured on another port
 	 */
 	rcc_peripheral_enable_clock(&RCC_AHB1ENR, BOARD_CLOCK_VBUS);
 	gpio_mode_setup(BOARD_PORT_VBUS, GPIO_MODE_INPUT, GPIO_PUPD_PULLDOWN, BOARD_PIN_VBUS);
 
-	/* check for USB VBUS present */
-	if (BOARD_PORT_VBUS, BOARD_PIN_VBUS) != 0) {
-		ret = true;
+	/* check if USB VBUS is not present */
+	if (gpio_get(BOARD_PORT_VBUS, BOARD_PIN_VBUS) == 0) {
+		ret = false;
 	}
 
 	/* deinitialise pin used to sniff VBUS
@@ -260,9 +261,10 @@ board_test_usb_vbus()
 	 */
 	gpio_mode_setup(BOARD_PORT_VBUS, GPIO_MODE_INPUT, GPIO_PUPD_NONE, BOARD_PIN_VBUS);
 
+#endif // !defined(BOARD_USB_VBUS_SENSE_DISABLED)
+
 	return ret;
 }
-#endif // #if !defined(BOARD_USB_VBUS_SENSE_DISABLED)
 #endif
 
 #if INTERFACE_USART
@@ -784,15 +786,10 @@ main(void)
 	 * If the force-bootloader pins are tied, we will stay here until they are removed and
 	 * we then time out.
 	 */
-#if defined(BOARD_USB_VBUS_SENSE_DISABLED)
-	try_boot = false;
-#else
 	if (board_test_usb_vbus()) {
 		/* don't try booting before we set up the bootloader */
 		try_boot = false;
 	}
-
-#endif // #if defined(BOARD_USB_VBUS_SENSE_DISABLED)
 #endif
 
 #if INTERFACE_USART

--- a/main_f7.c
+++ b/main_f7.c
@@ -236,6 +236,35 @@ board_test_force_pin()
 	return false;
 }
 
+#if INTERFACE_USB
+#if !defined(BOARD_USB_VBUS_SENSE_DISABLED)
+static bool
+board_test_usb_vbus()
+{
+	bool ret = false;
+
+	/* initialise pin to sample VBUS 
+	 * This is usually PA9, but could be configured on another port
+	 */
+	rcc_peripheral_enable_clock(&RCC_AHB1ENR, BOARD_CLOCK_VBUS);
+	gpio_mode_setup(BOARD_PORT_VBUS, GPIO_MODE_INPUT, GPIO_PUPD_PULLDOWN, BOARD_PIN_VBUS);
+
+	/* check for USB VBUS present */
+	if (BOARD_PORT_VBUS, BOARD_PIN_VBUS) != 0) {
+		ret = true;
+	}
+
+	/* deinitialise pin used to sniff VBUS
+	 * Note: the PA9 needs to be in its default state (floating input) if
+	 * VBUS sensing is enabled when the USB is initialised.
+	 */
+	gpio_mode_setup(BOARD_PORT_VBUS, GPIO_MODE_INPUT, GPIO_PUPD_NONE, BOARD_PIN_VBUS);
+
+	return ret;
+}
+#endif // #if !defined(BOARD_USB_VBUS_SENSE_DISABLED)
+#endif
+
 #if INTERFACE_USART
 static bool
 board_test_usart_receiving_break()
@@ -312,12 +341,6 @@ board_init(void)
 	gpio_mode_setup(BOARD_POWER_PORT, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, BOARD_POWER_PIN_OUT);
 	gpio_set_output_options(BOARD_POWER_PORT, GPIO_OTYPE_PP, GPIO_OSPEED_2MHZ, BOARD_POWER_PIN_OUT);
 	BOARD_POWER_ON(BOARD_POWER_PORT, BOARD_POWER_PIN_OUT);
-#endif
-
-#if INTERFACE_USB
-
-	/* enable Port A GPIO9 to sample VBUS */
-	rcc_peripheral_enable_clock(&RCC_AHB1ENR, RCC_AHB1ENR_IOPAEN);
 #endif
 
 #if INTERFACE_USART
@@ -764,14 +787,12 @@ main(void)
 #if defined(BOARD_USB_VBUS_SENSE_DISABLED)
 	try_boot = false;
 #else
-
-	if (gpio_get(GPIOA, GPIO9) != 0) {
-
+	if (board_test_usb_vbus()) {
 		/* don't try booting before we set up the bootloader */
 		try_boot = false;
 	}
 
-#endif
+#endif // #if defined(BOARD_USB_VBUS_SENSE_DISABLED)
 #endif
 
 #if INTERFACE_USART


### PR DESCRIPTION
The initilaisation, reading and deinitiliasation of PA9 is
preformed all in board_test_usb_vbus().

This also solves the problem, where PA9 was floating and
could erroneously have been read as being HIGH, and hence triggered
the board to stay in the bootloader until timeout, instead of booting
immediately.

Fixes issue #82.