### PR TITLE
Removes unused INTERFACE_USB ifdef from main_f3

### DIFF
--- a/main_f3.c
+++ b/main_f3.c
@@ -383,7 +383,7 @@ main(void)
 	/* do board-specific initialisation */
 	board_init();
 
-#if defined(INTERFACE_USART) | defined (INTERFACE_USB)
+#if defined(INTERFACE_USART)
 	/* XXX sniff for a USART connection to decide whether to wait in the bootloader? */
 	timeout = BOOTLOADER_DELAY;
 #endif


### PR DESCRIPTION
The main_f3.c compilation is only used with a UART interface at the
moment, so the USB interface check is unnecessary.