### PR TITLE
reserve code 0x33 for setting uart baudrate

### DIFF
--- a/bl.c
+++ b/bl.c
@@ -103,6 +103,7 @@
 #define PROTO_GET_CHIP_DES			0x2e    // read chip version In ASCII
 #define PROTO_BOOT					0x30    // boot the application
 #define PROTO_DEBUG					0x31    // emit debug information - format not defined
+#define PROTO_SET_BAUD				0x33    // set baud rate on uart
 
 #define PROTO_PROG_MULTI_MAX    64	// maximum PROG_MULTI size
 #define PROTO_READ_MULTI_MAX    255	// size of the size field


### PR DESCRIPTION
This is implemented in the ArduPilot bootloader, and we want to prevent the opcode being used for something else in PX4
