### PR TITLE
Windows 10 + Eclipse CDT + Cygwin

### DIFF
--- a/Makefile.f1
+++ b/Makefile.f1
@@ -16,8 +16,9 @@ FLAGS		+= -mthumb -mcpu=cortex-m3\
        -DTARGET_HW_$(TARGET_HW) \
        -DSTM32F1 \
 		   -T$(LINKER_FILE) \
-		   -L$(LIBOPENCM3)/lib \
-		   -lopencm3_stm32f1
+				-L$(LIBOPENCM3)/lib/stm32/F1 \
+				-lopencm3_stm32f1 \
+		   $(EXTRAFLAGS)
 
 #
 # General rules for making dependency and object files

--- a/Makefile.f3
+++ b/Makefile.f3
@@ -16,7 +16,7 @@ FLAGS 		+= -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
        -DTARGET_HW_$(TARGET_HW) \
        -DSTM32F3 \
        -T$(LINKER_FILE) \
-		   -L$(LIBOPENCM3)/lib \
+		   -L$(LIBOPENCM3)/lib/stm32/F3 \
 		   -lopencm3_stm32f3 \
         $(EXTRAFLAGS)
 

--- a/Makefile.f4
+++ b/Makefile.f4
@@ -19,7 +19,7 @@ FLAGS		+= -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 \
        -DTARGET_HW_$(TARGET_HW) \
        -DSTM32F4 \
        -T$(LINKER_FILE) \
-		   -L$(LIBOPENCM3)/lib \
+		   -L$(LIBOPENCM3)/lib/stm32/F4 \
 		   -lopencm3_stm32f4 \
         $(EXTRAFLAGS)
 

--- a/Makefile.f7
+++ b/Makefile.f7
@@ -17,9 +17,14 @@ LIBS			= opencm3_stm32f7 opencm3_stm32f4
 
 FLAGS			+= -g -mthumb -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-sp-d16 \
 				-DTARGET_HW_$(TARGET_HW) \
+				-DSTM32F7 \
 				-T$(LINKER_FILE) \
-				-L$(LIBOPENCM3)/lib $(addprefix -l, $(LIBS)) \
-				-DSTM32F7
+					-L$(LIBOPENCM3)/lib/stm32/F7 \
+					-lopencm3_stm32f7 \
+				-T$(LINKER_FILE) \
+					-L$(LIBOPENCM3)/lib/stm32/F4 \
+					-lopencm3_stm32f4 \
+				$(EXTRAFLAGS)
 
 # libopencm3 doesn't have USB driver in stm32f7 library, tell it to use the one from stm32f4
 # for the cdcacm


### PR DESCRIPTION
Hi!
When I try to build Bootloader through the PX4 Toolchain on the command line through the 'make' or "make px4fmuv5_bl" commands, the compiler throws an error "cannot find -lopencm3_stm32f4"
I solved this problem by editing the Make files. I wonder how Bootloader generally compiles if there are a lot of errors in Make files.After adjusting the make files, Bootloader compiles without errors through the PX4 Toolchaine console.
