### PR TITLE
Ensure the RTC is enabled and also do not mess with other bits in RCC_BDCR (especially for those in the Backup domain)

### DIFF
--- a/main_f4.c
+++ b/main_f4.c
@@ -199,7 +199,7 @@ board_get_rtc_signature()
 	uint32_t result = BOOT_RTC_REG;
 
 	/* disable the backup registers */
-	RCC_BDCR &= RCC_BDCR_RTCEN;
+	RCC_BDCR &= ~RCC_BDCR_RTCEN;
 	PWR_CR &= ~PWR_CR_DBP;
 
 	return result;
@@ -215,7 +215,7 @@ board_set_rtc_signature(uint32_t sig)
 	BOOT_RTC_REG = sig;
 
 	/* disable the backup registers */
-	RCC_BDCR &= RCC_BDCR_RTCEN;
+	RCC_BDCR &= ~RCC_BDCR_RTCEN;
 	PWR_CR &= ~PWR_CR_DBP;
 }
 

--- a/main_f4.c
+++ b/main_f4.c
@@ -199,7 +199,6 @@ board_get_rtc_signature()
 	uint32_t result = BOOT_RTC_REG;
 
 	/* disable the backup registers */
-	RCC_BDCR &= ~RCC_BDCR_RTCEN;
 	PWR_CR &= ~PWR_CR_DBP;
 
 	return result;
@@ -215,7 +214,6 @@ board_set_rtc_signature(uint32_t sig)
 	BOOT_RTC_REG = sig;
 
 	/* disable the backup registers */
-	RCC_BDCR &= ~RCC_BDCR_RTCEN;
 	PWR_CR &= ~PWR_CR_DBP;
 }
 

--- a/main_f7.c
+++ b/main_f7.c
@@ -188,7 +188,6 @@ board_get_rtc_signature()
 	uint32_t result = BOOT_RTC_REG;
 
 	/* disable the backup registers */
-	RCC_BDCR &= ~RCC_BDCR_RTCEN;
 	PWR_CR1 &= ~PWR_CR1_DBP;
 
 	return result;
@@ -204,7 +203,6 @@ board_set_rtc_signature(uint32_t sig)
 	BOOT_RTC_REG = sig;
 
 	/* disable the backup registers */
-	RCC_BDCR &= ~RCC_BDCR_RTCEN;
 	PWR_CR1 &= ~PWR_CR1_DBP;
 }
 

--- a/main_f7.c
+++ b/main_f7.c
@@ -188,7 +188,7 @@ board_get_rtc_signature()
 	uint32_t result = BOOT_RTC_REG;
 
 	/* disable the backup registers */
-	RCC_BDCR &= RCC_BDCR_RTCEN;
+	RCC_BDCR &= ~RCC_BDCR_RTCEN;
 	PWR_CR1 &= ~PWR_CR1_DBP;
 
 	return result;
@@ -204,7 +204,7 @@ board_set_rtc_signature(uint32_t sig)
 	BOOT_RTC_REG = sig;
 
 	/* disable the backup registers */
-	RCC_BDCR &= RCC_BDCR_RTCEN;
+	RCC_BDCR &= ~RCC_BDCR_RTCEN;
 	PWR_CR1 &= ~PWR_CR1_DBP;
 }
 


### PR DESCRIPTION
I found this when reading the code. It looks like a typo to me.

There are also other bits in the register `RCC_BDCR` which would be cleared after `RCC_BDCR &= RCC_BDCR_RTCEN` . This can be problematic. However, I did not see it caused any problem so far.