### PR TITLE
board_types.txt: sync to ArduPilot board_types.txt

### DIFF
--- a/board_types.txt
+++ b/board_types.txt
@@ -92,6 +92,7 @@ AP_HW_MRO_CONTROL_ZERO_OEM            142
 AP_HW_MATEKF765_WING                  143
 AP_HW_JDMINIF405                      144
 AP_HW_KAKUTEF7_MINI                   145
+AP_HW_H757I_EVAL                      146
 AP_HW_F4BY                             20 # value due to previous release by vendor
 AP_HW_VRBRAIN_V51                    1151
 AP_HW_VRBRAIN_V52                    1152
@@ -125,7 +126,34 @@ AP_HW_MRO_CTRL_ZERO_H7               1023
 AP_HW_MRO_CTRL_ZERO_OEM_H7           1024
 AP_HW_BEASTH7                        1025
 AP_HW_BEASTF7                        1026
+AP_HW_FlywooF745                     1027
+AP_HW_FreeflyRTK                     1028
+AP_HW_luminousbee5                   1029
+AP_HW_KAKUTEF4_MINI                  1030
+AP_HW_H31_PIXC4_PI                   1031
+AP_HW_H31_PIXC4_JETSON               1032
+AP_HW_CUBEORANGE_JOEY                1033
+AP_HW_SIERRAF9PGPS_PERIPH            1034
+AP_HW_HolybroGPS                     1035
+AP_HW_QioTekZealotH743               1036
+AP_HW_HEREPRO                        1037
+AP_HW_MAMBABASICF4                   1038
+AP_HW_ARGOSDYNE_DP1000               1039
+AP_HW_Nucleo491                      1040
+AP_HW_mRoM10095                      1041
+AP_HW_FlywooF745Nano                 1042
+AP_HW_HEREID                         1043
+AP_HW_BirdCANdy                      1044
+AP_HW_SKYSTARSF405DJI                1045
+AP_HW_HITEC_AIRSPEED                 1046
+AP_HW_NucleoL496                     1047
+AP_HW_KakuteH7                       1048
+AP_HW_ICSI_Kestrel                   1049
+AP_HW_SierraL431                     1050
+AP_HW_NucleoL476                     1051
+AP_HW_SierraF405                     1052
 
 AP_HW_CUBEORANGE_PERIPH              1400
 AP_HW_CUBEBLACK_PERIPH               1401
 AP_HW_PIXRACER_PERIPH                1402
+AP_HW_SWBOOMBOARD_PERIPH             1403


### PR DESCRIPTION
Additions to align with https://github.com/ArduPilot/ardupilot/blob/master/Tools/AP_Bootloader/board_types.txt
I think most of the "Reserved" lines are now implemented so could be removed, but I've not done that here.
Also, there is some duplication creeping in that might be worth discussing.