### PR TITLE
stm32: disable overrun

### DIFF
--- a/stm32/usart.c
+++ b/stm32/usart.c
@@ -59,6 +59,12 @@ uart_cinit(void *config)
 	usart_set_parity(usart, USART_PARITY_NONE);
 	usart_set_flow_control(usart, USART_FLOWCONTROL_NONE);
 
+#ifdef USART_CR3_OVRDIS
+	/* Disable overrun. Otherwise, an overrun leads to the situation where
+	 * we can't read from a UART anymore. */
+	USART_CR3(usart) |= USART_CR3_OVRDIS;
+#endif
+
 	/* and enable */
 	usart_enable(usart);
 


### PR DESCRIPTION
This was found on the Mantis where the following happened:
1. Boot command is sent to a bootloader without a firmware flashed.
2. After boot command, there is a 100 ms delay.
3. During that time, more data is sent to the bootloader causing an overrun.
4. Without overrun disabled, this will set the ORE flag, and reads will fail because RXNE is not set.

By disabling the overrun flag we can recover from an overrun.