### PR TITLE
board_types.txt: add KakuteH7v2 and KakuteH7mini

### DIFF
--- a/board_types.txt
+++ b/board_types.txt
@@ -160,6 +160,8 @@ AP_HW_ICSI_Kestrel                   1049
 AP_HW_SierraL431                     1050
 AP_HW_NucleoL476                     1051
 AP_HW_SierraF405                     1052
+AP_HW_KakuteH7v2                     1053
+AP_HW_KakuteH7mini                   1054
 
 AP_HW_CUBEORANGE_PERIPH              1400
 AP_HW_CUBEBLACK_PERIPH               1401


### PR DESCRIPTION
This adds two device_id to cover the KakuteH7v2 and the KakuteH7mini. Both warrant a separate ID and build target because they come with NAND flash rather than an SD card.

@vincentpoont2 can you also confirm that this is ok?