### PR TITLE
Change USBPRODUCTID for TARGET_HW_OMNIBUSF4SD

### DIFF
--- a/hw_config.h
+++ b/hw_config.h
@@ -786,7 +786,7 @@
 # define INTERFACE_USB                  1
 # define INTERFACE_USART                0
 # define USBDEVICESTRING                "PX4 OmnibusF4SD"
-# define USBPRODUCTID                   0x0016
+# define USBPRODUCTID                   0x0001
 
 # define BOARD_TYPE                     42
 # define BOARD_FLASH_SECTORS            11


### PR DESCRIPTION
There are issues with connecting FCUs based on omnibusf4sd to the latest version of QGroundControl. This is because QGroundControl expects omnibusf4sd to be of productID 0x0001 (as seen in [qgroundcontrol/src/comm/USBBoardInfo.json](https://github.com/mavlink/qgroundcontrol/blob/master/src/comm/USBBoardInfo.json)) but the bootloader reports it as productID 0x0016. This commit aims to fix this discrepancy and restore the productID value to the official one