### PR TITLE
board_types.txt: update reserved range comment for ArduPilot

### DIFF
--- a/board_types.txt
+++ b/board_types.txt
@@ -66,12 +66,12 @@ Reserved "NXP FMURT1170-V1"            35 # AKA PX4 FMU V6XRT
 # values from external vendors
 EXT_HW_RADIOLINK_MINI_PIX               3
 
-# NOTE: the full range from 1000 to 1999 (inclusive) is reserved for
+# NOTE: the full range from 1000 to 19999 (inclusive) is reserved for
 # use by the ArduPilot bootloader. Do not allocate IDs in this range
 # except via changes to the ArduPilot code
 
-# Do not allocate IDs in the range 1000 to 1999 except via a PR
-# against https://github.com/ArduPilot/ardupilot/tree/master/Tools/AP_Bootloader/board_types.txt
+# Do not allocate IDs in the range 1000 to 19999 except via a PR
+# against this file in https://github.com/ArduPilot/ardupilot/tree/master/Tools/AP_Bootloader/board_types.txt
 
 # values starting with AP_ are implemented in the ArduPilot bootloader
 # https://github.com/ArduPilot/ardupilot/tree/master/Tools/AP_Bootloader


### PR DESCRIPTION
obviously boards are being allocated outside the range mentioned in this comment.  Attempt to avoid conflicts in future by updating said comment