### PR TITLE
Add note about duplicate KakuteH7 mini entry

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,9 +12,9 @@ on:
 jobs:
   coverage:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install dependencies

--- a/board_types.txt
+++ b/board_types.txt
@@ -164,7 +164,7 @@ AP_HW_SierraL431                     1050
 AP_HW_NucleoL476                     1051
 AP_HW_SierraF405                     1052
 AP_HW_KakuteH7v2                     1053
-AP_HW_KakuteH7mini                   1054
+AP_HW_KakuteH7mini                   1054 # Deprecated, now 1058.
 AP_HW_SierraF412                     1055
 AP_HW_BEASTH7v2                      1056
 AP_HW_BEASTF7v2                      1057


### PR DESCRIPTION
The board ID 1054 is not used anymore for the KakuteH7 mini, instead it should all be 1058.

FYI @vincentpoont2