### PR TITLE
board_types: add Holybro KakuteH7-Wing

### DIFF
--- a/board_types.txt
+++ b/board_types.txt
@@ -109,6 +109,7 @@ AP_HW_JDMINIF405                      144
 AP_HW_KAKUTEF7_MINI                   145
 AP_HW_H757I_EVAL                      146
 AP_HW_F4BY                             20 # value due to previous release by vendor
+AP_HW_KakuteH7-Wing                  1105
 AP_HW_VRBRAIN_V51                    1151
 AP_HW_VRBRAIN_V52                    1152
 AP_HW_VRBRAIN_V54                    1154


### PR DESCRIPTION
As already used by ArduPilot.

With: https://github.com/PX4/PX4-Autopilot/pull/24669

Also see: https://github.com/ArduPilot/ardupilot/blob/fccd9600d8e5680f166e1ec1a1bf834b88fe563c/Tools/AP_Bootloader/board_types.txt#L227