### PR TITLE
board_types.txt: Add YARIV6X

### DIFF
--- a/board_types.txt
+++ b/board_types.txt
@@ -331,6 +331,9 @@ AP_HW_CSKY-PMU                       1212
 
 AP_HW_MUPilot                        1222
 
+# IDs 1231-1240 reserved for YARI Robotics
+AP_HW_YARIV6X                        1234
+
 AP_HW_CBUnmanned-CM405-FC            1301
 
 AP_HW_KHA_ETH                        1315


### PR DESCRIPTION
Hi, Updating this list based on a recent PR merge to allocate board id for YARIV6X https://github.com/ArduPilot/ardupilot/pull/30910