### PR TITLE
hw_config: set SaamPix BOARD_TYPE to numeric 200 for runtime protocol

### DIFF
--- a/hw_config.h
+++ b/hw_config.h
@@ -486,7 +486,7 @@
 # define USBPRODUCTID                   0x008E
 # define BOOT_DELAY_ADDRESS             0x000001a0
 
-# define BOARD_TYPE                      TARGET_HW_SAAMPIX_V1_1
+# define BOARD_TYPE                      200
 # define _FLASH_KBYTES                  (*(uint16_t *)0x1fff7a22)
 # define BOARD_FLASH_SECTORS            ((_FLASH_KBYTES == 0x400) ? 11 : 23)
 # define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)


### PR DESCRIPTION
Summary: set BOARD_TYPE for TARGET_HW_SAAMPIX_V1_1 to numeric 200 in hw_config.h (SaamPix-only one-line fix).
Why: during hardware verification, bootloader GET_DEVICE INFO_BOARD_ID returned 1 instead of 200 with macro-based assignment.
Verification: built saampixv1_1_bl, flashed hardware, queried bootloader over serial; runtime now reports BOARD_ID=200 and VID:PID=26AC:008E.\n\nScope: no changes to other board targets.