### PR TITLE
board_types: reserve IDs 110-119 for Syro, add SYRO_V6X

### DIFF
--- a/board_types.txt
+++ b/board_types.txt
@@ -90,6 +90,9 @@ Reserved "NXP MR-TROPIC"               37
 
 Reserved "MNP FMU V6X"                 70
 
+# IDs 110-119 reserved for Syro
+TARGET_HW_SYRO_V6X                     110
+
 # values from external vendors
 EXT_HW_RADIOLINK_MINI_PIX               3
 


### PR DESCRIPTION
Reserve ID for Syro V6X