### PR TITLE
Fix weekly sweep masking the conflict-check exit code

### DIFF
--- a/.github/workflows/weekly_board_conflicts.yaml
+++ b/.github/workflows/weekly_board_conflicts.yaml
@@ -21,6 +21,9 @@ jobs:
 
       - name: Run full-file conflict check
         id: check
+        # shell: bash runs with -o pipefail so the script's exit code is not
+        # masked by `tee` in the pipeline.
+        shell: bash
         run: ./Tools/check_board_types_conflicts.sh | tee conflict_output.txt
 
       # If the sweep failed, open a tracking issue or append to the existing


### PR DESCRIPTION
The weekly board conflict sweep was reporting success even when the check found a conflict. The check step pipes the script through `tee` to capture its output for the issue body, but the step ran under the default `bash -e` shell, which does not set `pipefail`. Without it the pipeline takes `tee`'s exit code (0), so the script's `exit 1` was swallowed and the job passed.

This is the same silent-failure class the check was built to catch. The manual dispatch right after merge made it obvious: the log printed `Conflict detected: Value "88" ...` and `ERROR: 1 board ID conflict(s) detected`, yet the job concluded success, the `Report failure` step was skipped, and no tracking issue was filed.

The fix sets `shell: bash` on the step, which GitHub runs with `-o pipefail`, so the script's exit code is no longer masked by `tee`. After this lands, a re-dispatch should fail on the existing id-88 conflict and open the tracking issue as intended.