### PR TITLE
add a board id AP_HW_DroneerX6

### DIFF
--- a/board_types.txt
+++ b/board_types.txt
@@ -512,6 +512,7 @@ AP_HW_IOMCU_F100                     5713
 
 #IDs 5800-5809 reserved for Droneer
 AP_HW_DroneerF405                    5800
+AP_HW_DroneerX6                      5801
 
 #IDs 5810-5819 reserved for Brother Hobby
 AP_HW_BrotherHobbyH743               5810


### PR DESCRIPTION
add a board id for DroneerX6