### PR TITLE
Add NewBeeDrone PixNova board id

### DIFF
--- a/board_types.txt
+++ b/board_types.txt
@@ -68,6 +68,7 @@ TARGET_HW_ATL_MANTIS_EDU               97
 TARGET_HW_THE_PEACH_K1                212
 TARGET_HW_THE_PEACH_R1                213
 TARGET_HW_SAAMPIX_V1_1                200
+TARGET_HW_NEWBEEDRONE_PIXNOVA        5900 # same as AP_HW_NewBeeDrone_PixNova
 
 Reserved  PX4 [BL] FMU v5X.x           51
 Reserved "PX4 [BL] FMU v6.x"           52
@@ -517,6 +518,9 @@ AP_HW_DroneerX6                      5801
 #IDs 5810-5819 reserved for Brother Hobby
 AP_HW_BrotherHobbyH743               5810
 AP_HW_BrotherHobbyF405v3             5811
+
+# IDs 5900-5909 reserved for NewBeeDrone PixNova
+AP_HW_NewBeeDrone_PixNova            5900 # same as TARGET_HW_NEWBEEDRONE_PIXNOVA
 
 # IDs 6000-6099 reserved for SpektreWorks
 AP_HW_sw-spar-f407                   6000

--- a/board_types.txt
+++ b/board_types.txt
@@ -68,8 +68,6 @@ TARGET_HW_ATL_MANTIS_EDU               97
 TARGET_HW_THE_PEACH_K1                212
 TARGET_HW_THE_PEACH_R1                213
 TARGET_HW_SAAMPIX_V1_1                200
-TARGET_HW_NEWBEEDRONE_PIXNOVA        5900 # same as AP_HW_NewBeeDrone_PixNova
-
 Reserved  PX4 [BL] FMU v5X.x           51
 Reserved "PX4 [BL] FMU v6.x"           52
 Reserved "PX4 [BL] FMU v6X.x"          53
@@ -520,7 +518,7 @@ AP_HW_BrotherHobbyH743               5810
 AP_HW_BrotherHobbyF405v3             5811
 
 # IDs 5900-5909 reserved for NewBeeDrone PixNova
-AP_HW_NewBeeDrone_PixNova            5900 # same as TARGET_HW_NEWBEEDRONE_PIXNOVA
+AP_HW_NewBeeDrone_PixNova            5900
 
 # IDs 6000-6099 reserved for SpektreWorks
 AP_HW_sw-spar-f407                   6000


### PR DESCRIPTION
Reserves the board ID for the upcoming NewBeeDrone PixNova flight controller.

We have also submitted a matching board ID reservation PR to ArduPilot to ensure consistency and prevent conflicts across both platforms.
